### PR TITLE
Feature/multiple clusters

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1815,7 +1815,9 @@ ${diff}
 `);
         const output = scrubSecrets(`
 ## ArgoCD Diff for commit [\`${shortCommitSha}\`](${commitLink})
-_Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })} PT_
+${ARGOCD_SERVER_URL}
+
+_Updated at ${new Date().toLocaleString('en-US', { timeZone: 'Europe/Amsterdam' })} CET_
   ${diffOutput.join('\n')}
 
 | Legend | Status |
@@ -1829,7 +1831,7 @@ _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angele
             owner,
             repo
         });
-        const existingComment = commentsResponse.data.find(d => d.body.includes('ArgoCD Diff for'));
+        const existingComment = commentsResponse.data.find(d => d.body.includes(ARGOCD_SERVER_URL));
         // Existing comments should be updated even if there are no changes this round in order to indicate that
         if (existingComment) {
             octokit.rest.issues.updateComment({

--- a/dist/index.js
+++ b/dist/index.js
@@ -1815,7 +1815,7 @@ ${diff}
 `);
         const output = scrubSecrets(`
 ## ArgoCD Diff for commit [\`${shortCommitSha}\`](${commitLink})
-${ARGOCD_SERVER_URL}
+### Cluster: [${ARGOCD_SERVER_URL}](https://${ARGOCD_SERVER_URL})
 
 _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'Europe/Amsterdam' })} CET_
   ${diffOutput.join('\n')}

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,6 +185,8 @@ ${diff}
 
   const output = scrubSecrets(`
 ## ArgoCD Diff for commit [\`${shortCommitSha}\`](${commitLink})
+${ARGOCD_SERVER_URL}
+
 _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })} PT_
   ${diffOutput.join('\n')}
 
@@ -201,7 +203,7 @@ _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angele
     repo
   });
 
-  const existingComment = commentsResponse.data.find(d => d.body!.includes('ArgoCD Diff for'));
+  const existingComment = commentsResponse.data.find(d => d.body!.includes(ARGOCD_SERVER_URL));
 
   // Existing comments should be updated even if there are no changes this round in order to indicate that
   if (existingComment) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -187,7 +187,7 @@ ${diff}
 ## ArgoCD Diff for commit [\`${shortCommitSha}\`](${commitLink})
 ${ARGOCD_SERVER_URL}
 
-_Updated at ${new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })} PT_
+_Updated at ${new Date().toLocaleString('en-US', { timeZone: 'Europe/Amsterdam' })} CET_
   ${diffOutput.join('\n')}
 
 | Legend | Status |

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,7 @@ ${diff}
 
   const output = scrubSecrets(`
 ## ArgoCD Diff for commit [\`${shortCommitSha}\`](${commitLink})
-${ARGOCD_SERVER_URL}
+### Cluster: [${ARGOCD_SERVER_URL}](https://${ARGOCD_SERVER_URL})
 
 _Updated at ${new Date().toLocaleString('en-US', { timeZone: 'Europe/Amsterdam' })} CET_
   ${diffOutput.join('\n')}


### PR DESCRIPTION
Add the name of the cluster in the comment and use the name of the cluster to update the comment if it exists.
This way we can preview multiple apps from multiple clusters in the same PR.

Also use Amsterdam timezone instead of LA.

Working prototype: https://github.com/GETProtocolLab/oesophagus/pull/215
Workflows change (hardcoded just for testing): https://github.com/GETProtocolLab/workflows/compare/master...feature/multiple-clusters

[sc-19974]